### PR TITLE
Configure Provider Port and DisableWebsocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ In order to connect to a real device you will need to set the IP of your compute
 export default withPerformanceMonitor(AwesomeChat, 'AwesomeChat', '192.168.1.10');
 ```
 
+By default the server is listening on port 8125 for event updates and 8126 for websocket.
+If you need to configure the port, because you are tunneling your request or similar, and or disable the Websocket communication, you can do it like this:
+
+```
+export default withPerformanceMonitor(AwesomeChat, 'AwesomeChat', '192.168.1.10', undefined, undefined, 80, false);
+```
+
 # How it works
 
 The overall implementation is quite straight forward and simply involved passing the onRenderCallback values via a websocket server to finally render them in a fancy graph.

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -3,8 +3,8 @@ import React, { Component } from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
 const Profiler = React.Profiler;
-export default (WrappedComponent, _id, ip = '127.0.0.1', events = ['mount', 'update'], showLogs = false) => {
-    const remote = `http://${ip}:8125/value`;
+export default (WrappedComponent, _id, ip = '127.0.0.1', events = ['mount', 'update'], showLogs = false, port = 8125, enableWS = true) => {
+    const remote = `http://${ip}:${port}/value`;
     const log = (message) => {
         if (showLogs) {
             console.log(message);
@@ -19,6 +19,7 @@ export default (WrappedComponent, _id, ip = '127.0.0.1', events = ['mount', 'upd
         }
 
         componentDidMount() {
+            if (!enableWS) return;
             this.socket = new WebSocket(`ws://${ip}:8126`);
             this.socket.onopen = function () {
                 log('RNPM: connected');
@@ -45,7 +46,7 @@ export default (WrappedComponent, _id, ip = '127.0.0.1', events = ['mount', 'upd
         }
 
         componentWillUnmount() {
-            this.socket.close();
+            this.socket && this.socket.close();
         }
 
         logMeasurement = async (id, phase, actualDuration) => {


### PR DESCRIPTION
Hello, on my current project we require to test the performance to connect the application behind a VPN and that does not make visible the computer running the performance-monitor server.

In order to connect the application to the server, instead of the IP address, we use a software to tunnel outside connections, but this software only listens on port 80, and the provider connects through port `8125` all the time.

We have tested this change on our side, where two extra arguments are added to the HOC and the request is made something like

```
export default withPerformanceMonitor(AwesomeChat, 'AwesomeChat', 'tunnelAddress.io', undefined, undefined, 80, false);
```

And we thought this might be helpful for other users.

I have added the arguments at the end of the provider and with default values, to make it backwards compatible with any other existing user.